### PR TITLE
Hack to enable .use(Device) to only call device init once

### DIFF
--- a/auto_scout.js
+++ b/auto_scout.js
@@ -56,10 +56,13 @@ AutoScout.prototype.init = function(cb) {
         var device = self.discover.apply(self, applyArgs);
       }
 
-      device.hash = deviceHash;
-      device.save(function() {
-        delete device.hash;
-      });
+      // device is not always populated in the case of .provision
+      if (device) {
+        device.hash = deviceHash;
+        device.save(function() {
+          delete device.hash;
+        });
+      }
     } else {
       var machine = self._deviceInstance;
       machine.hash = deviceHash;


### PR DESCRIPTION
Basically will reuse the instance if passed in as `this._deviceInstance` had to re add some code normally done in `this.discover` and `this.provision`.