### PR TITLE
Fixed issue with ._generat being called after .id is changed from registry

### DIFF
--- a/auto_scout.js
+++ b/auto_scout.js
@@ -64,13 +64,15 @@ AutoScout.prototype.init = function(cb) {
         });
       }
     } else {
-      var machine = self._deviceInstance;
+      var machine = self._deviceInstance.instance;
       machine.hash = deviceHash;
 
       if (results.length) {
         machine.id = results[0].id; // must set id before machine_config runs
         machine.name = results[0].name;
       }
+
+      machine._generate(self._deviceInstance.config);
 
       self.server.registry.save(machine, function(err){
         delete machine.hash;


### PR DESCRIPTION
Fixes issue in zetta https://github.com/zettajs/zetta/issues/152   https://github.com/zettajs/zetta/issues/153 for when device id changes after _generate is called.